### PR TITLE
Add cmd line args for katago exe and model folder

### DIFF
--- a/shape/katago/engine.py
+++ b/shape/katago/engine.py
@@ -24,11 +24,17 @@ class KataGoEngine:
         "stone_scoring": "stone_scoring",
     }
 
-    def __init__(self, katago_path):
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        config_path = os.path.join(base_dir, "models", "analysis.cfg")
-        model_path = os.path.join(base_dir, "models", "katago-28b.bin.gz")
-        human_model_path = os.path.join(base_dir, "models", "katago-human.bin.gz")
+    def __init__(self, katago_path, model_folder=None):
+        if model_folder == None:
+            base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        else:
+            print(model_folder)
+            base_dir = os.path.abspath(model_folder)
+            print(base_dir)
+
+        config_path = os.path.join(base_dir, "analysis.cfg")
+        model_path = os.path.join(base_dir, "katago-28b.bin.gz")
+        human_model_path = os.path.join(base_dir, "katago-human.bin.gz")
         if not os.path.exists(config_path) or not os.path.exists(model_path) or not os.path.exists(human_model_path):
             raise RuntimeError("Models not found. Run install.sh to download the models.")
 

--- a/shape/katago/engine.py
+++ b/shape/katago/engine.py
@@ -28,9 +28,7 @@ class KataGoEngine:
         if model_folder == None:
             base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         else:
-            print(model_folder)
             base_dir = os.path.abspath(model_folder)
-            print(base_dir)
 
         config_path = os.path.join(base_dir, "analysis.cfg")
         model_path = os.path.join(base_dir, "katago-28b.bin.gz")

--- a/shape/main.py
+++ b/shape/main.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import sys
 import traceback
+import argparse
 
 from PySide6.QtWidgets import QApplication
 
@@ -16,19 +17,20 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)  # hard exit on SIGINT
 
 
 class SHAPEApp:
-    def __init__(self):
+    def __init__(self, katago_path=None, model_folder=None):
         self.app = QApplication(sys.argv)
         self.main_window = MainWindow()
 
         # Use 'which katago' to find the KataGo executable
-        try:
-            katago_path = subprocess.check_output(["which", "katago"]).decode().strip()
-        except subprocess.CalledProcessError:
-            self.show_error("KataGo not found in PATH. Please install KataGo and make sure it's accessible.")
-            sys.exit(1)
+        if katago_path == None:
+            try:
+                katago_path = subprocess.check_output(["which", "katago"]).decode().strip()
+            except subprocess.CalledProcessError:
+                self.show_error("KataGo not found in PATH. Please install KataGo and make sure it's accessible.")
+                sys.exit(1)
 
         try:
-            self.katago = KataGoEngine(katago_path)
+            self.katago = KataGoEngine(katago_path, model_folder)
         except Exception as e:
             self.show_error(f"Failed to initialize KataGo engine: {e}")
             sys.exit(1)
@@ -44,7 +46,23 @@ class SHAPEApp:
 
 
 def main():
-    shape = SHAPEApp()
+    parser = argparse.ArgumentParser(
+            description='SHAPE: Shape Habits Analysis and Personalized Evaluation')
+    parser.add_argument('--katago', type=str, 
+                        help='Path to the katago executable (optional)', default=None)
+    parser.add_argument('--model_folder', type=str, 
+                        help='Path to the model folder (optional)', default=None)
+    args = parser.parse_args()
+
+    katago_path = None
+    if args.katago:
+        katago_path = args.katago
+
+    model_folder = None
+    if args.model_folder:
+        model_folder = args.model_folder
+
+    shape = SHAPEApp(katago_path, model_folder)
     sys.exit(shape.run())
 
 

--- a/shape/main.py
+++ b/shape/main.py
@@ -54,15 +54,7 @@ def main():
                         help='Path to the model folder (optional)', default=None)
     args = parser.parse_args()
 
-    katago_path = None
-    if args.katago:
-        katago_path = args.katago
-
-    model_folder = None
-    if args.model_folder:
-        model_folder = args.model_folder
-
-    shape = SHAPEApp(katago_path, model_folder)
+    shape = SHAPEApp(args.katago, args.model_folder)
     sys.exit(shape.run())
 
 


### PR DESCRIPTION
Assumptions about where the model folder existed hardcoded into the program made it difficult to install. This allows the user to install Shape, and it tell it where katago and the models folder exist via command line arguments.

This is the PR that solves #8 